### PR TITLE
Correct directions for packet sniffing

### DIFF
--- a/how_tos/how_to_sniff_zigbee_traffic.md
+++ b/how_tos/how_to_sniff_zigbee_traffic.md
@@ -10,11 +10,11 @@ Sniffing Zigbee traffic can be handy sometimes. E.g. when you want to analyze th
 ## 1. Flashing the CC2531 stick
 The CC2531 needs to be flashed with a sniffer firmware. Flash the firmware using the instructions from [Flashing the CC2531](../getting_started/flashing_the_cc2531.md).
 
-### Ubuntu
-For Ubuntu this firmware is included with [PACKET-SNIFFER](http://www.ti.com/tool/PACKET-SNIFFER) (not **PACKET-SNIFFER-2!**). Download and install PACKET-SNIFFER. The firmware can then be found here: `C:\Program Files (x86)\Texas Instruments\SmartRF Tools\Packet Sniffer\bin\general\firmware\sniffer_fw_cc2531.hex`.
+### Windows
+For Windows this firmware is included with [PACKET-SNIFFER](http://www.ti.com/tool/PACKET-SNIFFER) (not **PACKET-SNIFFER-2!**). Download and install PACKET-SNIFFER. The firmware can then be found here: `C:\Program Files (x86)\Texas Instruments\SmartRF Tools\Packet Sniffer\bin\general\firmware\sniffer_fw_cc2531.hex`.
 
-### Windows (and possibly Ubuntu)
-For Windows this firmware is included with [ZBOSS](http://zboss.dsr-wireless.com/downloads/index/zboss). Register an account and download *ZBOSS Sniffer for Windows 64-bit*. Included in the ZIP file is the firmware in subfolder `hw\CC2531 USB dongle\zboss_sniffer.hex`. Please note that ZBOSS is also available for Ubuntu.
+### Ubuntu (and other Linux distros)
+For Linux this firmware is included with [ZBOSS](http://zboss.dsr-wireless.com/downloads/index/zboss). Register an account and download *ZBOSS Sniffer for Windows 64-bit*. Included in the ZIP file is the firmware in subfolder `hw\CC2531 USB dongle\zboss_sniffer.hex`. Please note that ZBOSS is also available for Ubuntu.
 
 ## 2. Installing required tools
 


### PR DESCRIPTION
The directions for how to obtain the appropriate CC2531 firmware on Windows vs. Linux are incorrect. As described, it isn't possible to "Download and install PACKET-SNIFFER" and navigate to `C:\Program Files (x86)...` on a Linux platform; these appear to be the steps for Windows.